### PR TITLE
Fix error when g:opengoogletranslate#openbrowsercmd is empty.

### DIFF
--- a/autoload/opengoogletranslate.vim
+++ b/autoload/opengoogletranslate.vim
@@ -8,7 +8,7 @@ let g:opengoogletranslate#openbrowsercmd = get(g:, 'opengoogletranslate#openbrow
 " TODO: support removing comment prefix in given input?
 function! opengoogletranslate#open(...) abort
   let url = call('opengoogletranslate#url', a:000)
-  let [cmd; args] = split(g:opengoogletranslate#openbrowsercmd, ' ')
+  let [cmd; args] = split(g:opengoogletranslate#openbrowsercmd, ' ', 1)
   if executable(cmd) ==# 1
     call job_start([cmd] + args + [url])
     return


### PR DESCRIPTION
error:
  Error detected while processing function opengoogletranslate#command#command[12]
  ..opengoogletranslate#open:
  line    2:
  E688: More targets than List items