### PR TITLE
In neovim, job_start is not used and it corresponds to neovim.

### DIFF
--- a/autoload/opengoogletranslate.vim
+++ b/autoload/opengoogletranslate.vim
@@ -10,7 +10,11 @@ function! opengoogletranslate#open(...) abort
   let url = call('opengoogletranslate#url', a:000)
   let [cmd; args] = split(g:opengoogletranslate#openbrowsercmd, ' ', 1)
   if executable(cmd) ==# 1
-    call job_start([cmd] + args + [url])
+    if !has('nvim')
+      call job_start([cmd] + args + [url])
+    else
+      silent! call system([cmd] + args + [url])
+    endif
     return
   endif
   try


### PR DESCRIPTION
I wanted open-googletranslate to use neovim.
Since job of vim 8 can not be used by neovim, we changed it so that it works with synchronization processing for the moment.
Is there a problem with this change?