### PR TITLE
Fix duplicate tag due to notation mistake

### DIFF
--- a/doc/open-googletranslate.txt
+++ b/doc/open-googletranslate.txt
@@ -73,7 +73,7 @@ KEY MAPPINGS				*open-googletranslate-key-mappings*
 ==============================================================================
 OPTIONS					*open-googletranslate-options*
 
-g:opengoogletranslate#default_lang	*g:opengoogletranslate#default_lang*
+g:opengoogletranslate#default_lang	|g:opengoogletranslate#default_lang|
 	Default target language. The format should be two lowercase letters
 	(e.g. en, ja, etc...). Default is empty and inferred by |v:lang|.
 


### PR DESCRIPTION
Error `Vim(helptags):E154: Duplicate tag "g:opengoogletranslate#default_lang" in file /Users/username/.vim/bundle/.cache/.vimrc/.dein/doc/open-googletranslate.txt`